### PR TITLE
Fix the Travis CI status badge URL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ version 0.24-dev0
   * Extended Travis CI build with the tests under macOS 10.13 and 10.14
   * Enabled separate build of static and shared libraries
   * Extended Travis CI build with Ubuntu 20.04 jobs
+  * Fixed the URL for Travis CI build status badge.
 
 version 0.23-dev0
   * Added an ability to copy values between tables on-trace without guarded loads:

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 README for LuaVela (codename uJIT)
 ----------------------------------
 
-.. image:: https://travis-ci.org/iponweb/luavela.svg?branch=master
-    :target: https://travis-ci.org/iponweb/luavela
+.. image:: https://travis-ci.org/luavela/luavela.svg?branch=master
+    :target: https://travis-ci.org/luavela/luavela
 
 LuaVela is an interpreter and a Just-In-Time (JIT) compiler for the Lua
 programming language.
 
-Project Homepage: https://github.com/iponweb/luavela
+Project Homepage: https://github.com/luavela/luavela
 
 LuaVela is Copyright (C) 2015-2019 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 

--- a/etc/ujit.1
+++ b/etc/ujit.1
@@ -6,7 +6,7 @@ ujit \- Just-In-Time Compiler for the Lua Language
 .B ujit
 [\fIoptions\fR]... [\fIscript\fR [\fIargs\fR]...]
 .SH "WEB SITE"
-.IR https://github.com/iponweb/luavela
+.IR https://github.com/luavela/luavela
 .SH DESCRIPTION
 .PP
 This is the command-line program to run Lua programs with \fBuJIT\fR.

--- a/etc/ujit.pc.in
+++ b/etc/ujit.pc.in
@@ -14,7 +14,7 @@ INSTALL_CMOD=${prefix}/lib/lua/${abiver}
 
 Name: uJIT
 Description: Just-in-time compiler for Lua
-URL: https://github.com/iponweb/luavela
+URL: https://github.com/luavela/luavela
 Version: @UJIT_VERSION_STRING@
 Requires:
 Libs: -L${libdir} -l${libname}

--- a/src/ujit.h.in
+++ b/src/ujit.h.in
@@ -22,6 +22,6 @@
 #define UJIT_VERSION_STRING       "@UJIT_VERSION_STRING@"
 
 #define UJIT_COPYRIGHT "Copyright (C) 2015-2019 IPONWEB Ltd."
-#define UJIT_URL       "https://github.com/iponweb/luavela"
+#define UJIT_URL       "https://github.com/luavela/luavela"
 
 #endif /* !_UJIT_H */

--- a/tests/impl/uJIT-tests-C/suite/test_lua_yield.c
+++ b/tests/impl/uJIT-tests-C/suite/test_lua_yield.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
  *
  * This test is based on the reproducer provided by Arseny Vakhrushev
- * within https://github.com/iponweb/luavela/issues/12.
+ * within https://github.com/luavela/luavela/issues/12.
  */
 
 #include "test_common_lua.h"

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/profile-leaf/profile_aux.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/profile-leaf/profile_aux.lua
@@ -2,7 +2,7 @@
 -- Copyright (C) 2015-2019 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
 -- NB! Please do not name this file aux.lua, as a weird bug has been filed:
--- https://github.com/iponweb/luavela/issues/15
+-- https://github.com/luavela/luavela/issues/15
 
 local aux = {}
 

--- a/tests/lang/lua-Harness/suite/docs/index.md
+++ b/tests/lang/lua-Harness/suite/docs/index.md
@@ -11,7 +11,7 @@ This suite is usable with :
 
 - the standard [lua](http://www.lua.org/),
 - [LuaJIT](http://luajit.org/),
-- [LuaVela](https://github.com/iponweb/luavela),
+- [LuaVela](https://github.com/luavela/luavela),
 - ...
 
 See the given coverage :


### PR DESCRIPTION
Does what it says on the box: the badge is green now.

Additionally, all the links that were pointing to the old  `iponweb/luavela` repo were updated with `luavela/luavela`.