### PR TITLE
Remove unused variable

### DIFF
--- a/tools/parse_profile/ujpp_demangle.h
+++ b/tools/parse_profile/ujpp_demangle.h
@@ -12,7 +12,6 @@
 #include "ujpp_vector.h"
 #include "ujpp_utils.h"
 
-struct vector v;
 struct parser_state;
 struct hvmstate;
 


### PR DESCRIPTION
The removed variable is excess. Besides it's declared in header file and
breaks uJIT build on GCC 10 with multiple definition error.

Fixes #33