### PR TITLE
Fix lua-Harness .gitattribute entry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-tests/lang/lua-Harness/suite/public/* linguist-vendored
+tests/lang/lua-Harness/suite/public/** linguist-vendored


### PR DESCRIPTION
.gitattribute parsing rules have been changed in rugged[1] between v0.28.5 and v1.0.0 (I believe something changed in libgit2, but it requires a bit more time to found the particular revision and I also guess it is required only for the history, so I gave up). As a result linguist[2] fails to find all files to be suppressed that are specified via the pattern in .gitattributes entry. Several users have been also experienced the same effect (for more info see github/linguist#5439 and github/linguist#5451).

The fix itself is quite trivial: to suppress the files located not only in the specified directory, but also all in its subdirectories, double asterisk glob has to be used.

[1]: https://github.com/libgit2/rugged
[2]: https://github.com/github/linguist

Signed-off-by: Igor Munkin <imun@cpan.org>