### PR TITLE
Fix key duplication in lj_tab_toset

### DIFF
--- a/src/lj_tab.c
+++ b/src/lj_tab.c
@@ -1046,7 +1046,7 @@ GCtab* lj_tab_toset(lua_State *L, const GCtab *src)
     if (src_v == NULL || tvisnil(src_v))
       break;
 
-    dst_v = lj_tab_newkey(L, dst, src_v);
+    dst_v = lj_tab_set(L, dst, src_v);
     setboolV(dst_v, 1);
   }
 

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/table/toset/mutated.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/table/toset/mutated.lua
@@ -4,6 +4,7 @@
 -- Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 require("jit").off()
 
+local utils = require("utils")
 local toset = require("ujit.table").toset
 local tests = {}
 
@@ -93,6 +94,19 @@ function tests.nil_last_explicit_int_keys()
 	local s = toset(t)
 	assert(s.abc == true)
 	assert(s.def == nil)
+end
+
+function tests.duplicates()
+	local t = {"abc", "def"}
+	for i = 1, #t do
+		table.insert(t, t[i])
+	end
+	assert(utils.count(t) == 4)
+
+	local s = toset(t)
+	assert(s.abc == true)
+	assert(s.def == true)
+	assert(utils.count(s) == 2)
 end
 
 for _, test in pairs(tests) do


### PR DESCRIPTION
Before the patch `lj_tab_toset` uses `lj_tab_newkey` helper to insert the new key into resulting set. As a result, the new slot in GCtab object is allocated unconditionally (i.e. without the check whether the given key is already stored in this table) causing key duplication in the resulting table violating "set" definition.

Within the patch `lj_tab_newkey` is replaced with `lj_tab_set` helper, that yields the existing slot if the given key is stored in the table, or allocate the new slot otherwise.

Fixes #38

Signed-off-by: Igor Munkin <imun@cpan.org>