### PR TITLE
Introduce GitHub Actions on macOS

### DIFF
--- a/.github/actions/setup-macos/README.md
+++ b/.github/actions/setup-macos/README.md
@@ -1,0 +1,12 @@
+# Setup environment on macOS
+
+Action setups the environment on macOS runners (install requirements, setup the
+workflow environment, etc).
+
+## How to use Github Action from Github workflow
+
+Add the following code to the running steps before uJIT configuration:
+```
+- uses: ./.github/actions/setup-macos
+  if: ${{ matrix.OS == 'macOS' }}
+```

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -1,0 +1,14 @@
+name: Setup CI environment on macOS
+description: Common part to tweak macOS CI runner environment
+runs:
+  using: composite
+  steps:
+    - name: Setup CI environment
+      uses: ./.github/actions/setup
+    - name: Set CMAKE_BUILD_PARALLEL_LEVEL
+      run: |
+        # Set CMAKE_BUILD_PARALLEL_LEVEL environment variable to
+        # limit the number of parallel jobs for build/test step.
+        NPROC=$(sysctl -n hw.logicalcpu 2>/dev/null)
+        echo CMAKE_BUILD_PARALLEL_LEVEL=$(($NPROC + 1)) | tee -a $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,15 +34,25 @@ jobs:
       fail-fast: false
       matrix:
         BUILDTYPE: [Debug, Release]
-        OS: [Linux]
+        OS: [Linux, macOS]
         LIBTYPE: [shared, static]
         CC: [GCC, Clang]
         include:
           - OS: Linux
             RUNNER: [ubuntu-20.04]
             TESTOPTIONS: -DUJIT_TEST_OPTIONS=-O4
+          - OS: macOS
+            RUNNER: [macos-11]
           - CC: Clang
             TOOLCHAIN: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/Clang.cmake
+        exclude:
+          # XXX: Strictly saying, macOS simply aliases `gcc' to AppleClang
+          # compiler, and this exclude rule just signals that AppleClang
+          # doesn't need any extra tweaks of the testing environment.
+          - OS: macOS
+            CC: Clang
+          - OS: macOS
+            LIBTYPE: shared
     runs-on: ${{ matrix.RUNNER }}
     name: >
       ${{ matrix.OS }}
@@ -53,6 +63,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: setup Linux
         uses: ./.github/actions/setup-linux
+        if: ${{ matrix.OS == 'Linux' }}
+      - name: setup macOS
+        uses: ./.github/actions/setup-macos
+        if: ${{ matrix.OS == 'macOS' }}
       - name: configure
         run: >
           cmake -S . -B ${{ env.BUILDDIR }}

--- a/src/lib/ujit.c
+++ b/src/lib/ujit.c
@@ -590,7 +590,7 @@ LJLIB_CF(ujit_profile_stop)
 	setnumfield(L, t_cnt, "_NUM_OVERRUNS", counters.num_overruns);
 
 	/* t_cnt["_ID"] = tostring(counters.id) */
-	sprintf(profile_id, "%#018llx", (unsigned long long)counters.id);
+	sprintf(profile_id, "%#017llx", (unsigned long long)counters.id);
 	lua_pushstring(L, profile_id);
 	lua_setfield(L, -2, "_ID");
 


### PR DESCRIPTION
The first commit extends GitHub Actions workflow matrix to test LuaVela on macOS (macOS Big Sur in particular) against different build types (i.e. Debug and Release). LuaVela is built only via the default compiler (AppleClang) with only static libujit to be used in LuaVela binary built for tests.

There is also GitHub Action for macOS environment setup introduced in scope of this commit. However, it looks like all requirements have already been pre-installed on GitHub hosted public macOS runners, so there is no need to install extra tools within the new GitHub Action.

The second commit fixes profile ID buffer overflow, that was found by quite strict AppleClang compiler configuration (-Werror, -Wfortify-source).