### PR TITLE
Fix flaky tests for instrumenting profiler

### DIFF
--- a/tests/impl/uJIT-tests-C/suite/test_lua_iprof.c
+++ b/tests/impl/uJIT-tests-C/suite/test_lua_iprof.c
@@ -4,10 +4,80 @@
  * Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
  */
 
+#include <time.h>
 #include <unistd.h>
 #include "test_common_lua.h"
 
-#define EPSILON 1e-1
+#define EPSILON 1e-6
+
+/* Clock emulation {{{ */
+
+/*
+ * We try to make the test less fragile by removing its dependence on the system
+ * time by overriding <clock_gettime(3)> function. For this reason, clock mock
+ * static counter is introduced and <clock_gettime> simply adds a jiffy to this
+ * counter, normalizes .nsec and .sec fields of the mock and respectively sets
+ * the value to the given struct timespec argument.
+ *
+ * According to jargon file (http://www.catb.org/~esr/jargon/html/J/jiffy.html):
+ * | 1. The duration of one tick of the system clock on your computer. Often one
+ * |    AC cycle time (1/60 second in the U.S. and Canada, 1/50 most other
+ * |    places), but more recently 1/100 sec has become common. "The swapper
+ * |    runs every 6 jiffies" means that the virtual memory management routine
+ * |    is executed once for every 6 ticks of the clock, or about ten times a
+ * |    second.
+ * | 2. Confusingly, the term is sometimes also used for a 1-millisecond wall
+ * |    time interval.
+ * | 3. Even more confusingly, physicists semi-jokingly use 'jiffy' to mean the
+ * |    time required for light to travel one foot in a vacuum, which turns out
+ * |    to be close to one nanosecond. Other physicists use the term for the
+ * |    quantum-mechanical lower bound on meaningful time lengths.
+ * | 4. Indeterminate time from a few seconds to forever. "I'll do it in a
+ * |    jiffy" means certainly not now and possibly never. This is a bit
+ * |    contrary to the more widespread use of the word. Oppose nano.
+ *
+ * Besides, there are several <sleep(3)> calls required in the test cases to
+ * check whether "lua" and "wall" counters are calculated right. This function
+ * is also overridden, considering how time is counted within this test: since
+ * <sleep> receives the seconds as an argument, simply add the given amount of
+ * seconds to the clock mock.
+ *
+ * Unfortunately, there is one flaw in such time mocking: these are not real
+ * nanoseconds and seconds used in the clock mock, but just two types of
+ * counters: short (for consecutive actions) and long (for interrupted actions).
+ * Hence, we can't use some real jiffy value (i.e. the first one from the jargon
+ * file), considering the cumulative discrepancy between linear mocked clock
+ * behaviour and non-linear real clock behaviour.
+ *
+ * Considering everything above "physicists semi-joking" constant (i.e. 1 ns)
+ * looks fine to be a jiffy in for a clock mock.
+ */
+#define JIFFY (1L)
+#define NSECNORM ((long)1e9)
+
+static struct timespec clock_mock = {
+	.tv_sec = 0,
+	.tv_nsec = 0,
+};
+
+extern int clock_gettime(clockid_t clockid, struct timespec *tp)
+{
+	UNUSED(clockid);
+	clock_mock.tv_nsec += JIFFY;
+	clock_mock.tv_sec += clock_mock.tv_nsec / NSECNORM;
+	clock_mock.tv_nsec = clock_mock.tv_nsec % NSECNORM;
+	tp->tv_sec = clock_mock.tv_sec;
+	tp->tv_nsec = clock_mock.tv_nsec;
+	return 0;
+}
+
+extern unsigned int sleep(unsigned int seconds)
+{
+	clock_mock.tv_sec += seconds;
+	return 0;
+}
+
+/* }}} */
 
 const char *ujit_iprof_profile =
 	" return function (pfn, pcb, name, mode, level)                   "


### PR DESCRIPTION
After enabling GitHub Actions to run all uJIT tests by the commit cd557a9 ("Enable GitHub Actions for testing LuaVela on Linux"), `iprof` tests fails from time to time. As a result of the investigation it was found that only the tests simulating real coroutine switches are affected. Since there is no way to tweak CI public runners provided by GitHub, we can't rely on the environment and have to mock time-related interfaces used in the aforementioned tests.

To reduce the dependency on the system clock, two libc functions are overridden in scope of this patch:
* `sleep(3)`: simply increments second counter stored in the clock mock by the given amount of seconds.
* `clock_gettime(3)`: increments nanosecond counter stored in the clock mock by the JIFFY value (i.e. 1 ns), normalizes the resulting counter value, incrementing second counter if necessary, and fills the given struct timespec argument with the "current" time.

Among the aforementioned tests there is the one using this sleep function from Lua space via FFI. Unfortunately, such overriding doesn't work for libc functions used via FFI, since ffi.C.* functions are obtained via RTLD_DEFAULT pseudo-handle (using this handle, `dlsym(3)` searches all objects in the current process in load-order, and libc.so is loaded prior to the executable).

Hence, FFI can't be used for this test and Lua C function comes as an alternative: `sleep(3)` is used in scope of the test executable and `sleep_lua` wrapper is registered and used in Lua space.

Fixes #41