### PR TITLE
Update Clang Tidy version

### DIFF
--- a/scripts/depends-test-20-04
+++ b/scripts/depends-test-20-04
@@ -1,6 +1,6 @@
 bc
 clang-format-6.0
-clang-tidy-6.0
+clang-tidy-11
 gdb
 graphviz
 libcmocka-dev=1.1.5-2

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -21,7 +21,7 @@ use constant DEFAULTS => {
 	project => '.',
 	clang_tidy => {
 		prefix => '/usr/bin/clang-tidy',
-		versions => [ qw(6.0) ],
+		versions => [ qw(11) ],
 	},
 	tries => 3,
 };

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -45,6 +45,8 @@ use constant CHECKS => {
 		'-android-*',
 		# no C++-specific checks
 		'-boost-*',
+		# suppressed by https://github.com/luavela/luavela/issues/53
+		'-bugprone-branch-clone',
 		# much noise, little value
 		'-bugprone-misplaced-widening-cast',
 		# much noise, little value

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -129,6 +129,14 @@ use constant CHECKS => {
 		'src/uj_gdbjit.c' => [
 			'-hicpp-no-assembler',
 		],
+		# Suppressed by https://github.com/luavela/luavela/issues/52.
+		'tools/parse_profile/ujpp_demangle_lua.c' => [
+			'-bugprone-not-null-terminated-result',
+		],
+		# Suppressed by https://github.com/luavela/luavela/issues/52.
+		'src/dump/uj_dump_bc.c' => [
+			'-bugprone-not-null-terminated-result',
+		],
 		# Include CRC calculation API to avoid uJIT linking.
 		'tests/impl/uJIT-tests-C/suite/test_crc.c' => [
 			'-bugprone-suspicious-include',

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -65,12 +65,13 @@ use constant CHECKS => {
 		'-cppcoreguidelines-*',
 		# not following Google conventions
 		'-google-*',
-		# contradicts LKSG
-		'-hicpp-braces-around-statements',
-		# much noise, little value
-		'-hicpp-no-assembler',
-		# much noise, little value
-		'-hicpp-static-assert',
+		# HIC++ mostly contains aliases
+		'-hicpp-*',
+		# except the following
+		'hicpp-exception-baseclass',
+		'hicpp-multiway-paths-covered',
+		'hicpp-no-assembler',
+		'hicpp-signed-bitwise',
 		# much noise, little value
 		'-hicpp-signed-bitwise',
 		# not following LLVM conventions
@@ -120,10 +121,10 @@ use constant CHECKS => {
 		'src/uj_meta.c' => [
 			'-clang-analyzer-core.NullDereference'
 		],
-        # Long test cases are totally reasonable here.
-        'tests/impl/uJIT-tests-C/suite/test_emit_sse2.c' => [
-            '-hicpp-function-size'
-        ],
+		# The only file using inline assembler to interact with GDB.
+		'src/uj_gdbjit.c' => [
+			'-hicpp-no-assembler',
+		],
 	}
 };
 

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -49,6 +49,8 @@ use constant CHECKS => {
 		'-bugprone-branch-clone',
 		# much noise, little value
 		'-bugprone-misplaced-widening-cast',
+		# suppressed by https://github.com/luavela/luavela/issues/54
+		'-bugprone-narrowing-conversions',
 		# much noise, little value
 		'-bugprone-reserved-identifier',
 		# false positives in our code base

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -75,6 +75,8 @@ use constant CHECKS => {
 		'-hicpp-signed-bitwise',
 		# not following LLVM conventions
 		'-llvm-*',
+		# not using LLVM libc
+		'-llvmlibc-*',
 		# much noise, little value
 		'-misc-static-assert',
 		# no C++-specific checks

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -127,6 +127,26 @@ use constant CHECKS => {
 		'src/uj_gdbjit.c' => [
 			'-hicpp-no-assembler',
 		],
+		# Include CRC calculation API to avoid uJIT linking.
+		'tests/impl/uJIT-tests-C/suite/test_crc.c' => [
+			'-bugprone-suspicious-include',
+		],
+		# Include LEB128/ULEB128 encoding API to avoid uJIT linking.
+		'tests/impl/uJIT-tests-C/suite/test_leb128.c' => [
+			'-bugprone-suspicious-include',
+		],
+		# Include random HEX file extension API to avoid uJIT linking.
+		'tests/impl/uJIT-tests-C/suite/test_random.c' => [
+			'-bugprone-suspicious-include',
+		],
+		# Include common string utils API to avoid uJIT linking.
+		'tests/impl/uJIT-tests-C/suite/test_str.c' => [
+			'-bugprone-suspicious-include',
+		],
+		# Include string scanning API to avoid uJIT linking.
+		'tests/impl/uJIT-tests-C/suite/test_strscan.c' => [
+			'-bugprone-suspicious-include',
+		],
 	}
 };
 

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -53,6 +53,8 @@ use constant CHECKS => {
 		'-bugprone-narrowing-conversions',
 		# much noise, little value
 		'-bugprone-reserved-identifier',
+		# suppressed by https://github.com/luavela/luavela/issues/55
+		'-bugprone-signed-char-misuse',
 		# false positives in our code base
 		'-bugprone-sizeof-expression',
 		# not following CERT guidelines

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -153,6 +153,12 @@ use constant CHECKS => {
 			'-clang-analyzer-core.uninitialized.Assign',
 			'-clang-analyzer-core.UndefinedBinaryOperatorResult',
 		],
+		# The risk of breaking things is much higher than
+		# a potential benefit from fixing away a single warning.
+		# See more info in https://github.com/luavela/luavela/issues/59.
+		'src/jit/lj_asm.c' => [
+			'-clang-analyzer-core.uninitialized.Branch',
+		],
 		# Include CRC calculation API to avoid uJIT linking.
 		'tests/impl/uJIT-tests-C/suite/test_crc.c' => [
 			'-bugprone-suspicious-include',

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -159,6 +159,24 @@ use constant CHECKS => {
 		'src/jit/lj_asm.c' => [
 			'-clang-analyzer-core.uninitialized.Branch',
 		],
+		# The risk of breaking things is much higher than
+		# a potential benefit from fixing away a single warning.
+		# See more info in https://github.com/luavela/luavela/issues/60.
+		'src/jit/opt/mem.c' => [
+			'-clang-analyzer-core.NullDereference',
+		],
+		# The risk of breaking things is much higher than
+		# a potential benefit from fixing away a single warning.
+		# See more info in https://github.com/luavela/luavela/issues/60.
+		'src/lib/string.c' => [
+			'-clang-analyzer-core.NullDereference',
+		],
+		# The risk of breaking things is much higher than
+		# a potential benefit from fixing away a single warning.
+		# See more info in https://github.com/luavela/luavela/issues/60.
+		'src/lj_tab.c' => [
+			'-clang-analyzer-core.NullDereference',
+		],
 		# Include CRC calculation API to avoid uJIT linking.
 		'tests/impl/uJIT-tests-C/suite/test_crc.c' => [
 			'-bugprone-suspicious-include',

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -118,11 +118,6 @@ use constant CHECKS => {
 		'src/uj_meta.c' => [
 			'-clang-analyzer-core.NullDereference'
 		],
-		# An obvious false positive specific to clang-tidy 5.0.
-		# TODO: Please remove after upgrade:
-		'src/frontend/lj_bcread.c' => [
-			'-misc-redundant-expression'
-		],
         # Long test cases are totally reasonable here.
         'tests/impl/uJIT-tests-C/suite/test_emit_sse2.c' => [
             '-hicpp-function-size'

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -61,6 +61,8 @@ use constant CHECKS => {
 		'-clang-analyzer-optin.osx.*',
 		# no OSX-specific checks
 		'-clang-analyzer-osx.*',
+		# much noise, little value
+		'-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling',
 		# no C++-specific checks
 		'-cppcoreguidelines-*',
 		# not following Google conventions

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -45,6 +45,10 @@ use constant CHECKS => {
 		'-android-*',
 		# no C++-specific checks
 		'-boost-*',
+		# much noise, little value
+		'-bugprone-misplaced-widening-cast',
+		# false positives in our code base
+		'-bugprone-sizeof-expression',
 		# not following CERT guidelines
 		'-cert-*',
 		# no unstable checks
@@ -71,10 +75,6 @@ use constant CHECKS => {
 		'-hicpp-signed-bitwise',
 		# not following LLVM conventions
 		'-llvm-*',
-		# much noise, little value
-		'-misc-misplaced-widening-cast',
-		# false positives in our code base
-		'-misc-sizeof-expression',
 		# much noise, little value
 		'-misc-static-assert',
 		# no C++-specific checks

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -145,6 +145,12 @@ use constant CHECKS => {
 		'src/dump/uj_dump_bc.c' => [
 			'-bugprone-not-null-terminated-result',
 		],
+		# The risk of breaking things is much higher than
+		# a potential benefit from fixing away a single warning.
+		# See more info in https://github.com/luavela/luavela/issues/57.
+		'src/jit/lj_record.c' => [
+			'-clang-analyzer-core.uninitialized.Assign',
+		],
 		# Include CRC calculation API to avoid uJIT linking.
 		'tests/impl/uJIT-tests-C/suite/test_crc.c' => [
 			'-bugprone-suspicious-include',

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -88,6 +88,8 @@ use constant CHECKS => {
 		'-llvm-*',
 		# not using LLVM libc
 		'-llvmlibc-*',
+		# suppressed by https://github.com/luavela/luavela/issues/56
+		'-misc-no-recursion',
 		# much noise, little value
 		'-misc-static-assert',
 		# no C++-specific checks

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -47,6 +47,8 @@ use constant CHECKS => {
 		'-boost-*',
 		# much noise, little value
 		'-bugprone-misplaced-widening-cast',
+		# much noise, little value
+		'-bugprone-reserved-identifier',
 		# false positives in our code base
 		'-bugprone-sizeof-expression',
 		# not following CERT guidelines

--- a/scripts/run-clang-tidy
+++ b/scripts/run-clang-tidy
@@ -147,9 +147,11 @@ use constant CHECKS => {
 		],
 		# The risk of breaking things is much higher than
 		# a potential benefit from fixing away a single warning.
-		# See more info in https://github.com/luavela/luavela/issues/57.
+		# See more info in https://github.com/luavela/luavela/issues/57
+		# and https://github.com/luavela/luavela/issues/58 respectively.
 		'src/jit/lj_record.c' => [
 			'-clang-analyzer-core.uninitialized.Assign',
+			'-clang-analyzer-core.UndefinedBinaryOperatorResult',
 		],
 		# Include CRC calculation API to avoid uJIT linking.
 		'tests/impl/uJIT-tests-C/suite/test_crc.c' => [

--- a/src/jit/lj_asm_x86.h
+++ b/src/jit/lj_asm_x86.h
@@ -1072,7 +1072,7 @@ static void asm_fxload(ASMState *as, IRIns *ir) {
 
 static void asm_fxstore(ASMState *as, IRIns *ir) {
   RegSet allow = RSET_GPR;
-  Reg src = RID_NONE, osrc = RID_NONE;
+  Reg src = RID_NONE;
   int32_t k = 0;
   if (ir->r == RID_SINK) { return; }
   /* The IRT_I16/IRT_U16 stores should never be simplified for constant
@@ -1081,7 +1081,7 @@ static void asm_fxstore(ASMState *as, IRIns *ir) {
   if (irt_isi16(ir->t) || irt_isu16(ir->t) || irt_isfp(ir->t) ||
       !asm_isk32(as, ir->op2, &k)) {
     RegSet allow8 = irt_isfp(ir->t) ? RSET_FPR : RSET_GPR;
-    src = osrc = ra_alloc1(as, ir->op2, allow8);
+    src = ra_alloc1(as, ir->op2, allow8);
     rset_clear(allow, src);
   }
   if (ir->o == IR_FSTORE) {

--- a/tests/impl/uJIT-tests-C/suite/test_cci_immutable.c
+++ b/tests/impl/uJIT-tests-C/suite/test_cci_immutable.c
@@ -5,7 +5,7 @@
  */
 
 #include "test_common.h"
-#include "jit/lj_ir.c"
+#include "jit/lj_ircall.h"
 
 /* Tests that all CCallInfo with CCI_IMMUTABLE flag are Stores */
 

--- a/tests/impl/uJIT-tests-C/suite/test_str.c
+++ b/tests/impl/uJIT-tests-C/suite/test_str.c
@@ -7,7 +7,6 @@
 #include "test_common.h"
 
 #include <string.h>
-#include <utils/lj_char.c>
 #include <utils/str.c>
 
 #define TEST_STR_BUFFER_SIZE 256


### PR DESCRIPTION
Clang Tidy is upgraded up to version 11.0.0 to make seamless migration from Ubuntu 20.04 to Ubuntu 22.04 (both distros provide the mentioned version of Clang toolchain from the default repositories). Further Clang toolchain upgrades will be completed after full migration to Ubuntu 22.04.

It's not quite easy to properly fix all the issues reported by Clang Tidy, so some of them are filed as a tickets in the GitHub queue and temporarily suppressed in `run-clang-tidy` runner.

