### PR TITLE
Fix build for Ubuntu 24.04 toolchain

### DIFF
--- a/cmake/toolchain/Clang.cmake
+++ b/cmake/toolchain/Clang.cmake
@@ -6,3 +6,19 @@
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
 set(CMAKE_C_COMPILER "clang-6.0")
+
+# XXX: Clang 15 changes the behaviour of -Wnull-pointer-arithmetics to control
+# -Wgnu-null-pointer-arithmetics either. Since uJIT is built with -Wextra
+# (including -Wnull-pointer-arithmetics) and -Werror flags being set in
+# CMAKE_C_FLAGS list, compilation of src/utils/lj_alloc.c fails due to NULL
+# pointer arithmetics in TOP_FOOT_SIZE constant definition. Furthermore,
+# -Wno-gnu flag to silence GNU extension diagnostics for pointer arithmetic is
+# allowed since Clang 15 (https://github.com/llvm/llvm-project/issues/54444)
+# too. Considering everything above, tweak the CMAKE_C_FLAGS list for Clang
+# toolchain only for Clang 15.0.0 and later.
+string(REGEX MATCH "clang-([0-9]+([.][0-9]+([.][0-9]+([-][0-9]+)?)?)?)"
+       CLANG_VERSION ${CMAKE_C_COMPILER})
+set(CLANG_VERSION ${CMAKE_MATCH_1})
+if(CLANG_VERSION VERSION_GREATER_EQUAL "15.0.0")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-null-pointer-arithmetic")
+endif()

--- a/src/utils/lj_alloc.c
+++ b/src/utils/lj_alloc.c
@@ -65,13 +65,13 @@
 #define MFAIL                   ((void *)(MAX_SIZE_T))
 #define CMFAIL                  ((char *)(MFAIL)) /* defined for convenience */
 
-static struct alloc_stats* get_stats()
+static struct alloc_stats* get_stats(void)
 {
   static struct alloc_stats stats = {0};
   return &stats;
 }
 
-struct alloc_stats uj_alloc_stats()
+struct alloc_stats uj_alloc_stats(void)
 {
   struct alloc_stats stats = {0};
   stats.active = __sync_fetch_and_or(&(get_stats()->active), 0);

--- a/src/utils/random.c
+++ b/src/utils/random.c
@@ -8,7 +8,7 @@
 #include <limits.h>
 #include <time.h>
 
-unsigned int random_time_seed() {
+unsigned int random_time_seed(void) {
   time_t timeval;      /* Current time. */
   unsigned char *ptr;  /* Type punned pointed into timeval. */
   unsigned int   seed; /* Generated seed. */

--- a/src/utils/random.h
+++ b/src/utils/random.h
@@ -14,7 +14,7 @@
 ** http://benpfaff.org/writings/clc/random-seed.html
 ** Example usage: srandom(random_time_seed());
 */
-unsigned int random_time_seed();
+unsigned int random_time_seed(void);
 
 /* Generate a random file extension consisting of the initial '.' character
 ** and (n - 1) random lower-case hexadecimal digits. Generated result is written

--- a/tests/impl/uJIT-tests-C/suite/test_common.h
+++ b/tests/impl/uJIT-tests-C/suite/test_common.h
@@ -14,8 +14,16 @@
 #include <cmocka.h>
 
 #include <math.h>
+/*
+ * XXX: cmocka provides <assert_double_equal> helper since 1.1.6 version.
+ * Nevertheless, to support all available cmocka versions (at least while
+ * transitioning period), <assert_double_equal> helper is defined below, if
+ * none is provided by cmocka.
+ */
+#ifndef assert_double_equal
 #define assert_double_equal(x, y, p) \
 	assert_true(fabs(((double)(x)) - ((double)(y))) < (p))
+#endif
 
 #define UNUSED(x) ((void)(x))
 #define UNUSED_STATE(state) UNUSED(state)

--- a/tests/impl/uJIT-tests-C/suite/test_common_lua.h
+++ b/tests/impl/uJIT-tests-C/suite/test_common_lua.h
@@ -25,7 +25,7 @@ static UJ_UNIT_AINLINE void assert_stack_size(lua_State *L, int expected_size)
 }
 
 /* Create a new Lua state and run some trivial integrity checks */
-static UJ_UNIT_AINLINE lua_State *test_lua_open()
+static UJ_UNIT_AINLINE lua_State *test_lua_open(void)
 {
 	lua_State *L = lua_open();
 

--- a/tests/impl/uJIT-tests-C/suite/test_cstr.c
+++ b/tests/impl/uJIT-tests-C/suite/test_cstr.c
@@ -51,7 +51,7 @@ static void assert_fromnum(lua_Number n, const char *ref)
 
 __attribute__((noinline)) /* Otherwise Werror will fail the build */
 static lua_Number
-zero()
+zero(void)
 {
 	return 0.0;
 }


### PR DESCRIPTION
I tried to build uJIT on Ubuntu Noble Numbat (development branch) Docker image. The diff I made for build and test requirements are below:
```diff
diff --git a/cmake/toolchain/Clang.cmake b/cmake/toolchain/Clang.cmake
index c5fcb28..82fb2eb 100644
--- a/cmake/toolchain/Clang.cmake
+++ b/cmake/toolchain/Clang.cmake
@@ -5,7 +5,7 @@
 # Copyright (C) 2020-2023 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-set(CMAKE_C_COMPILER "clang-6.0")
+set(CMAKE_C_COMPILER "clang-18")
 
 # XXX: Clang 15 changes the behaviour of -Wnull-pointer-arithmetics to control
 # -Wgnu-null-pointer-arithmetics either. Since uJIT is built with -Wextra
diff --git a/scripts/depends-build-20-04 b/scripts/depends-build-20-04
index 2850d4b..3008a0e 100644
--- a/scripts/depends-build-20-04
+++ b/scripts/depends-build-20-04
@@ -1,9 +1,9 @@
 autoconf
-clang-6.0
+clang-18
 cmake
 gcc
-gcc-8=8.4.0-*
+gcc-13
 libc6-dev
-libstdc++-8-dev
+libstdc++-10-dev
 libstdc++6
 libtool
diff --git a/scripts/depends-test-20-04 b/scripts/depends-test-20-04
index 58d3fd4..c1e0f6d 100644
--- a/scripts/depends-test-20-04
+++ b/scripts/depends-test-20-04
@@ -1,9 +1,9 @@
 bc
-clang-format-6.0
-clang-tidy-11
+clang-format-18
+clang-tidy-18
 gdb
 graphviz
-libcmocka-dev=1.1.5-2
+libcmocka-dev=1.1.7-3
 libdigest-crc-perl
 libfile-find-rule-perl
 liblist-allutils-perl
```

---

My experiments result to the following patchset.

The first patch fixes `assert_double_equal` redefinition. Since [1.1.6](https://git.cryptomilk.org/projects/cmocka.git/commit/?h=cmocka-1.1.6&id=f1e161507ba1e71a7cd33405461e639c586ad59e) version cmocka provides `assert_double_equal` helper. Nevertheless, to support all available cmocka versions (at least while the transitioning period), `assert_double_equal` helper is defined, if none is provided by cmocka.

The second patch fixes function declarations without a prototype throughout the project. Clang 15 modified the behavior of `-Wstrict-prototypes`, that now only diagnoses deprecated declarations and definitions of functions without a prototype where the behavior in [C2x](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2841.htm) will remain correct. This diagnostic emits build error in uJIT due to `-Werror -pedantic` flags being set in `CMAKE_C_FLAGS` list. See [release notes](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html) for more info.

The third patch suppresses `-Wgnu-null-pointer-arithmetics` for Clang 15 and later. Clang 15 changes the behaviour of `-Wnull-pointer-arithmetics` to control `-Wgnu-null-pointer-arithmetics` either. Since uJIT is built with `-Wextra` (including `-Wnull-pointer-arithmetics`) and `-Werror` flags being set in `CMAKE_C_FLAGS` list, compilation of [src/utils/lj_alloc.c](https://github.com/luavela/luavela/blob/master/src/utils/lj_alloc.c#L360-L361) fails due to NULL pointer arithmetics in `TOP_FOOT_SIZE` constant definition. Furthermore, `-Wno-gnu` flag to silence GNU extension diagnostics for pointer arithmetic is allowed since Clang 15 (llvm/llvm-project#54444). Considering everything above, tweak the `CMAKE_C_FLAGS` list for Clang toolchain only for Clang 15.0.0 and later.
    
It's worth to mention, that fixing the root cause of the warning is also an option to fix the issue, but it's better to be in sync with the LuaJIT upstream at this point.

---

@keeprocking, please let me know, whether everything is OK as a result of the series. I expect both build and tests against the toolchain on Ubuntu 24.04 (Noble Numbat) being fine. Everything related to the sanitizers will be adjusted later (we're still moving to Ubuntu 22.04 and Clang 11).