### PR TITLE
Update Clang Format version

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ BinPackArguments: true
 BinPackParameters: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Linux
-BreakBeforeTernaryOperators: false
+BreakBeforeTernaryOperators: true
 BreakStringLiterals: false
 ColumnLimit: 80
 DerivePointerAlignment: false

--- a/scripts/depends-test-20-04
+++ b/scripts/depends-test-20-04
@@ -1,5 +1,5 @@
 bc
-clang-format-6.0
+clang-format-11
 clang-tidy-11
 gdb
 graphviz

--- a/scripts/run-clang-format
+++ b/scripts/run-clang-format
@@ -25,7 +25,7 @@ use constant {
 		verbose => 0,
 		clang_format => {
 			prefix => '/usr/bin/clang-format',
-			versions => [ qw(6.0) ],
+			versions => [ qw(11) ],
 		},
 	},
 	EXCLUDE => {

--- a/src/dump/uj_dump_datadef.c
+++ b/src/dump/uj_dump_datadef.c
@@ -67,7 +67,7 @@ LJ_DATADEF const char *const dump_trace_errors[] = {
 
 /* Names of link types. ORDER LJ_TRLINK */
 LJ_DATADEF const char *const dump_trace_lt_names[] = {
-	"none",		"root",		  "loop",	"tail-recursion",
+	"none",		"root",		  "loop",	 "tail-recursion",
 	"up-recursion", "down-recursion", "interpreter", "return"};
 
 LJ_DATADEF const char *const dump_progress_state_names[] = {

--- a/src/dump/uj_dump_datadef_regs_x86.h
+++ b/src/dump/uj_dump_datadef_regs_x86.h
@@ -11,5 +11,5 @@ LJ_DATADEF const char *const dump_reg_gpr_names[] = {
 
 /* x86_64 SSE register names. */
 LJ_DATADEF const char *const dump_reg_fpr_names[] = {
-	"xmm0", "xmm1", "xmm2",  "xmm3",  "xmm4",  "xmm5",  "xmm6",  "xmm7",
+	"xmm0", "xmm1", "xmm2",	 "xmm3",  "xmm4",  "xmm5",  "xmm6",  "xmm7",
 	"xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"};

--- a/src/dump/uj_dump_progress.c
+++ b/src/dump/uj_dump_progress.c
@@ -93,8 +93,8 @@ static void dump_progress_trace_abort(FILE *out, const jit_State *J, void *data)
 	pc = abortstate->pc;
 
 	while (!isluafunc(frame_func(frame))) {
-		pc = frame_iscont(frame) ? frame_contpc(frame) :
-					   frame_pc(frame);
+		pc = frame_iscont(frame) ? frame_contpc(frame)
+					 : frame_pc(frame);
 		pc--;
 		frame = frame_prev(frame);
 	}

--- a/src/dump/uj_dump_stack.c
+++ b/src/dump/uj_dump_stack.c
@@ -119,8 +119,8 @@ static ptrdiff_t dump_frame_slot(FILE *out, const lua_State *L,
 	}
 
 	fprintf(out, " delta=%lu ",
-		(unsigned long)(frame_islua(slot) ? frame_deltal(slot) :
-						    frame_delta(slot)));
+		(unsigned long)(frame_islua(slot) ? frame_deltal(slot)
+						  : frame_delta(slot)));
 
 	uj_dump_func_description(out, fn, 0);
 	fprintf(out, "\n");
@@ -193,8 +193,8 @@ static void dump_value_slot(FILE *out, const lua_State *L, const TValue *slot)
 static void dump_bottom_slot(FILE *out, const lua_State *L, const TValue *slot)
 {
 	dump_print_stack_anchor(out, L, slot);
-	fprintf(out, frame_isdummy(L, slot) ? "FRAME: dummy L\n" :
-					      "FRAME: [UNKNOWN BOTTOM]\n");
+	fprintf(out, frame_isdummy(L, slot) ? "FRAME: dummy L\n"
+					    : "FRAME: [UNKNOWN BOTTOM]\n");
 }
 
 void uj_dump_stack(FILE *out, const lua_State *L)

--- a/src/dump/uj_dump_stack.c
+++ b/src/dump/uj_dump_stack.c
@@ -12,10 +12,11 @@
 #define SLOT_VALUE_BUFFER_SIZE 40
 #define SLOT_VALUE_COPY_THRESHOLD 30
 
-enum { FRAME_LIVE, /* Live frame, chain linked
+enum {
+	FRAME_LIVE, /* Live frame, chain linked
 		     * with other frames on the stack
 		     */
-       FRAME_DEAD /* Dead frame, left between two active frames */
+	FRAME_DEAD /* Dead frame, left between two active frames */
 };
 
 static void dump_print_stack_anchor(FILE *out, const lua_State *L,

--- a/src/jit/emit/uj_emit_ct.c
+++ b/src/jit/emit/uj_emit_ct.c
@@ -124,8 +124,8 @@ static MCode *emit_jccs(ASMState *as, x86CC cc, const MCode *target)
 {
 	struct ctins ins = emit_ctins_init(as, SIZEOF_JCCS_OP, SIZEOF_JCCS);
 	*(uint8_t *)(ins.op) = emit_jccs_op(cc);
-	*(int8_t *)(ins.rel) = NULL != target ? emit_rel8(ins.next_pc, target) :
-						JCCS_BACKEDGE_DUMMY_TARGET;
+	*(int8_t *)(ins.rel) = NULL != target ? emit_rel8(ins.next_pc, target)
+					      : JCCS_BACKEDGE_DUMMY_TARGET;
 	emit_ctins_commit(as, &ins);
 	return ins.pc;
 }

--- a/src/jit/uj_record_indexed.c
+++ b/src/jit/uj_record_indexed.c
@@ -68,8 +68,8 @@ static int record_handle_mobj(struct jit_State *J, struct RecordIndex *ix)
 	}
 
 	/* Handle metamethod call. */
-	func = lj_record_mm_prep(J, record_is_store(ix) ? lj_cont_nop :
-							  lj_cont_ra);
+	func = lj_record_mm_prep(J, record_is_store(ix) ? lj_cont_nop
+							: lj_cont_ra);
 	base = J->base + func;
 	tv = J->L->base + func;
 
@@ -444,9 +444,9 @@ static TRef record_idx(struct jit_State *J, struct RecordIndex *ix)
 	ix->xrefop = IR(tref_ref(ix->xref))->o;
 	ix->loadop = ix->xrefop == IR_AREF ? IR_ALOAD : IR_HLOAD;
 	/* The uj_meta_tset() inconsistency is gone, but better play safe. */
-	ix->oldval = ix->xrefop == IR_KKPTR ?
-			     (const TValue *)ir_kptr(IR(tref_ref(ix->xref))) :
-			     ix->oldv;
+	ix->oldval = ix->xrefop == IR_KKPTR
+			     ? (const TValue *)ir_kptr(IR(tref_ref(ix->xref)))
+			     : ix->oldv;
 
 	if (record_is_store(ix))
 		return record_indexed_store(J, ix);

--- a/src/profile/uj_iprof.c
+++ b/src/profile/uj_iprof.c
@@ -428,13 +428,13 @@ void uj_iprof_tick(lua_State *L, enum iprof_ev_type type)
 	case IPROF_START:
 	case IPROF_CALL:
 		iprof_entity_acc(L, entity, IPROF_KEY_WALL,
-				 type == IPROF_START ?
-					 tick * (iprof->mode == IPROF_PLAIN) :
-					 -tick);
+				 type == IPROF_START
+					 ? tick * (iprof->mode == IPROF_PLAIN)
+					 : -tick);
 		iprof_entity_acc(L, entity, IPROF_KEY_LUA,
-				 type == IPROF_START ?
-					 tick * (iprof->mode == IPROF_PLAIN) :
-					 -tick);
+				 type == IPROF_START
+					 ? tick * (iprof->mode == IPROF_PLAIN)
+					 : -tick);
 
 		if (iprof->mode == IPROF_PLAIN)
 			break;

--- a/src/uj_capi.c
+++ b/src/uj_capi.c
@@ -67,9 +67,8 @@ TValue *uj_capi_index2adr(lua_State *L, int idx)
 			return o;
 		} else {
 			idx = LUA_GLOBALSINDEX - idx;
-			return idx <= fn->c.nupvalues ?
-				       &fn->c.upvalue[idx - 1] :
-				       niltv(L);
+			return idx <= fn->c.nupvalues ? &fn->c.upvalue[idx - 1]
+						      : niltv(L);
 		}
 	}
 }
@@ -777,8 +776,8 @@ LUA_API void *lua_upvalueid(lua_State *L, int idx, int n)
 	GCfunc *fn = funcV(uj_capi_index2adr(L, idx));
 	n--;
 	api_check(L, (uint32_t)n < fn->l.nupvalues);
-	return isluafunc(fn) ? (void *)(fn->l.uvptr[n]) :
-			       (void *)&fn->c.upvalue[n]; /* TODO: check! */
+	return isluafunc(fn) ? (void *)(fn->l.uvptr[n])
+			     : (void *)&fn->c.upvalue[n]; /* TODO: check! */
 }
 
 LUA_API void lua_upvaluejoin(lua_State *L, int idx1, int n1, int idx2, int n2)
@@ -1056,8 +1055,8 @@ LUA_API int lua_gc(lua_State *L, int what, int data)
 		g->gc.threshold = LJ_MAX_MEM;
 		break;
 	case LUA_GCRESTART:
-		g->gc.threshold = (data == -1) ? (total / 100) * g->gc.pause :
-						 total;
+		g->gc.threshold = (data == -1) ? (total / 100) * g->gc.pause
+					       : total;
 		break;
 	case LUA_GCCOLLECT:
 		lj_gc_fullgc(L);

--- a/src/uj_dwarf.c
+++ b/src/uj_dwarf.c
@@ -112,9 +112,9 @@ static int dwarf_cleanup(int actions, uint64_t uexclass,
 	if (cframe != NULL) {
 		/* Reached landing pad to the user code. */
 		_Unwind_SetGR(ctx, UJ_TARGET_EHRETREG, ex);
-		_Unwind_SetIP(ctx, (uintptr_t)(uj_cframe_unwind_is_ff(cframe) ?
-						       lj_vm_unwind_ff_eh :
-						       lj_vm_unwind_c_eh));
+		_Unwind_SetIP(ctx, (uintptr_t)(uj_cframe_unwind_is_ff(cframe)
+						       ? lj_vm_unwind_ff_eh
+						       : lj_vm_unwind_c_eh));
 		return _URC_INSTALL_CONTEXT;
 	}
 

--- a/src/uj_gdbjit.c
+++ b/src/uj_gdbjit.c
@@ -166,13 +166,15 @@ void LJ_NOINLINE __jit_debug_register_code(void)
 
 /* -- In-memory ELF object definitions ------------------------------------ */
 
-enum { DW_CFA_nop = 0x0,
-       DW_CFA_offset_extended = 0x5,
-       DW_CFA_def_cfa = 0xc,
-       DW_CFA_def_cfa_offset = 0xe,
-       DW_CFA_offset_extended_sf = 0x11,
-       DW_CFA_advance_loc = 0x40,
-       DW_CFA_offset = 0x80 };
+enum {
+	DW_CFA_nop = 0x0,
+	DW_CFA_offset_extended = 0x5,
+	DW_CFA_def_cfa = 0xc,
+	DW_CFA_def_cfa_offset = 0xe,
+	DW_CFA_offset_extended_sf = 0x11,
+	DW_CFA_advance_loc = 0x40,
+	DW_CFA_offset = 0x80
+};
 
 enum { DW_EH_PE_udata4 = 3, DW_EH_PE_textrel = 0x20 };
 
@@ -180,17 +182,21 @@ enum { DW_TAG_compile_unit = 0x11 };
 
 enum { DW_children_no = 0, DW_children_yes = 1 };
 
-enum { DW_AT_name = 0x03,
-       DW_AT_stmt_list = 0x10,
-       DW_AT_low_pc = 0x11,
-       DW_AT_high_pc = 0x12 };
+enum {
+	DW_AT_name = 0x03,
+	DW_AT_stmt_list = 0x10,
+	DW_AT_low_pc = 0x11,
+	DW_AT_high_pc = 0x12
+};
 
 enum { DW_FORM_addr = 0x01, DW_FORM_data4 = 0x06, DW_FORM_string = 0x08 };
 
-enum { DW_LNS_extended_op = 0,
-       DW_LNS_copy = 1,
-       DW_LNS_advance_pc = 2,
-       DW_LNS_advance_line = 3 };
+enum {
+	DW_LNS_extended_op = 0,
+	DW_LNS_copy = 1,
+	DW_LNS_advance_pc = 2,
+	DW_LNS_advance_line = 3
+};
 
 enum { DW_LNE_end_sequence = 1, DW_LNE_set_address = 2 };
 
@@ -216,16 +222,18 @@ enum {
 };
 
 /* Minimal list of sections for the in-memory ELF object. */
-enum { GDBJIT_SECT_NULL,
-       GDBJIT_SECT_text,
-       GDBJIT_SECT_eh_frame,
-       GDBJIT_SECT_shstrtab,
-       GDBJIT_SECT_strtab,
-       GDBJIT_SECT_symtab,
-       GDBJIT_SECT_debug_info,
-       GDBJIT_SECT_debug_abbrev,
-       GDBJIT_SECT_debug_line,
-       GDBJIT_SECT__MAX };
+enum {
+	GDBJIT_SECT_NULL,
+	GDBJIT_SECT_text,
+	GDBJIT_SECT_eh_frame,
+	GDBJIT_SECT_shstrtab,
+	GDBJIT_SECT_strtab,
+	GDBJIT_SECT_symtab,
+	GDBJIT_SECT_debug_info,
+	GDBJIT_SECT_debug_abbrev,
+	GDBJIT_SECT_debug_line,
+	GDBJIT_SECT__MAX
+};
 
 enum { GDBJIT_SYM_UNDEF, GDBJIT_SYM_FILE, GDBJIT_SYM_FUNC, GDBJIT_SYM__MAX };
 

--- a/src/uj_lib.c
+++ b/src/uj_lib.c
@@ -254,8 +254,8 @@ int uj_lib_checkopt(lua_State *L, unsigned int narg, int def, const char *lst)
 	uint8_t len;
 	int i;
 
-	const GCstr *s = def >= 0 ? uj_lib_optstr(L, narg) :
-				    uj_lib_checkstr(L, narg);
+	const GCstr *s = def >= 0 ? uj_lib_optstr(L, narg)
+				  : uj_lib_checkstr(L, narg);
 
 	if (NULL == s)
 		return def;

--- a/src/uj_sigtimer.c
+++ b/src/uj_sigtimer.c
@@ -42,16 +42,16 @@ static enum sigtimer_status sigtimer_install_sa(struct sigtimer *timer)
 	if (sigemptyset(&sa.sa_mask) != 0)
 		return SIGTIMER_ERR;
 
-	return sigaction(timer->opt.signo, &sa, &timer->old_sa) == 0 ?
-		       SIGTIMER_SUCCESS :
-		       SIGTIMER_ERR;
+	return sigaction(timer->opt.signo, &sa, &timer->old_sa) == 0
+		       ? SIGTIMER_SUCCESS
+		       : SIGTIMER_ERR;
 }
 
 static enum sigtimer_status sigtimer_uninstall_sa(const struct sigtimer *timer)
 {
-	return sigaction(timer->opt.signo, &timer->old_sa, NULL) == 0 ?
-		       SIGTIMER_SUCCESS :
-		       SIGTIMER_ERR;
+	return sigaction(timer->opt.signo, &timer->old_sa, NULL) == 0
+		       ? SIGTIMER_SUCCESS
+		       : SIGTIMER_ERR;
 }
 
 static enum sigtimer_status sigtimer_create(struct sigtimer *timer)
@@ -63,9 +63,9 @@ static enum sigtimer_status sigtimer_create(struct sigtimer *timer)
 	se.sigev_notify = SIGEV_THREAD_ID;
 	se._sigev_un._tid = syscall(SYS_gettid);
 
-	return timer_create(CLOCK_MONOTONIC, &se, &(timer->id)) == 0 ?
-		       SIGTIMER_SUCCESS :
-		       SIGTIMER_ERR;
+	return timer_create(CLOCK_MONOTONIC, &se, &(timer->id)) == 0
+		       ? SIGTIMER_SUCCESS
+		       : SIGTIMER_ERR;
 }
 
 /* Low-level timer removal. */
@@ -85,8 +85,8 @@ static enum sigtimer_status sigtimer_start(const struct sigtimer *timer)
 	tm.it_interval.tv_sec = tm.it_value.tv_sec = sec;
 	tm.it_interval.tv_nsec = tm.it_value.tv_nsec = nsec;
 
-	return timer_settime(timer->id, 0, &tm, NULL) == 0 ? SIGTIMER_SUCCESS :
-							     SIGTIMER_ERR;
+	return timer_settime(timer->id, 0, &tm, NULL) == 0 ? SIGTIMER_SUCCESS
+							   : SIGTIMER_ERR;
 }
 
 /* Low-level timer disarming. Currently async-signal-safe. */
@@ -95,8 +95,8 @@ static enum sigtimer_status sigtimer_stop(const struct sigtimer *timer)
 	struct itimerspec tm;
 
 	memset(&tm, 0, sizeof(struct itimerspec));
-	return timer_settime(timer->id, 0, &tm, NULL) == 0 ? SIGTIMER_SUCCESS :
-							     SIGTIMER_ERR;
+	return timer_settime(timer->id, 0, &tm, NULL) == 0 ? SIGTIMER_SUCCESS
+							   : SIGTIMER_ERR;
 }
 
 /* Public API */

--- a/src/uj_state.c
+++ b/src/uj_state.c
@@ -358,8 +358,8 @@ lua_State *uj_state_newstate(const struct luae_Options *opt)
 	uj_strhash_t *strhash_sealed;
 	int cpluaopen_status;
 	lua_State *datastate = opt != NULL ? opt->datastate : NULL;
-	enum luaext_HashF hashftype = opt != NULL ? opt->hashftype :
-						    LUAE_HASHF_DEFAULT;
+	enum luaext_HashF hashftype = opt != NULL ? opt->hashftype
+						  : LUAE_HASHF_DEFAULT;
 
 	uj_global_init();
 

--- a/src/uj_str.c
+++ b/src/uj_str.c
@@ -312,8 +312,8 @@ static GCstr *str_cat(lua_State *L, TValue *bottom, TValue *top)
 
 	for (i = 0; i < nslots; i++) {
 		const TValue *tv = &bottom[i];
-		const size_t len = tvisstr(tv) ? strV(tv)->len :
-						 LUAI_MAXNUMBER2STR;
+		const size_t len = tvisstr(tv) ? strV(tv)->len
+					       : LUAI_MAXNUMBER2STR;
 
 		lua_assert(uj_str_is_coercible(tv));
 

--- a/src/utils/strhash/city.c
+++ b/src/utils/strhash/city.c
@@ -160,9 +160,9 @@ static uint32_t Hash32Len5to12(const char *s, size_t len)
 static uint32_t CityHash32(const char *s, size_t len)
 {
 	if (len <= 24) {
-		return len <= 12 ? (len <= 4 ? Hash32Len0to4(s, len) :
-					       Hash32Len5to12(s, len)) :
-				   Hash32Len13to24(s, len);
+		return len <= 12 ? (len <= 4 ? Hash32Len0to4(s, len)
+					     : Hash32Len5to12(s, len))
+				 : Hash32Len13to24(s, len);
 	}
 
 	/* len > 24 */

--- a/tools/parse_profile/ujpp_table.c
+++ b/tools/parse_profile/ujpp_table.c
@@ -112,8 +112,8 @@ size_t table_calc_cfunc_len(struct parser_state *ps, size_t i)
 	const struct cfunc_cache *cache =
 		ujpp_vector_at(&ps->vec_cfunc_cache, cf->cache_id);
 
-	return cache->symbol ? strlen(cache->symbol) + SPACE_NUM :
-			       NOT_RESOLVED_SYM_LEN;
+	return cache->symbol ? strlen(cache->symbol) + SPACE_NUM
+			     : NOT_RESOLVED_SYM_LEN;
 }
 
 void ujpp_table_cfunc_length(struct parser_state *ps)
@@ -231,9 +231,9 @@ void ujpp_table_lfunc_length(struct parser_state *ps)
 		const struct lfunc_cache *lf_c =
 			ps->vec_lfunc_cache.elems[lf->cache_id];
 		size_t demangled_len = DEMANGLE_LUA_FAILED ==
-						       lf_c->demangled_sym ?
-					       0 :
-					       strlen(lf_c->demangled_sym);
+						       lf_c->demangled_sym
+					       ? 0
+					       : strlen(lf_c->demangled_sym);
 
 		len = demangled_len + strlen(lf_c->sym) +
 		      table_digits(lf_c->line) + 8;


### PR DESCRIPTION
Clang Format is upgraded up to version 11.0.0 to make seamless migration from Ubuntu 20.04 to Ubuntu 22.04 (both distros provide the mentioned version of Clang toolchain from the default repositories). Further Clang toolchain upgrades will be completed after full migration to Ubuntu 22.04.

---

Within the first patch, the current chosen formatting policy for `BreakBeforeTernaryOperators` (i.e. `false`) is broken since Clang Format 11.0.0, causing a misindent for the sources following the line break. What's even more upsetting is that this misindent is fixed only in Clang Format 14.0.0. So, this bug makes us to reformat all the ternary operators now, and revert this change after upgrading Clang toolchain to 14.0.0.

I believe, that the chosen policy is not widely used, otherwise it would not be broken for three major releases. For comparison, if this options is set to `true`, the code is fine for all Clang Format versions from 6.0.0 to 18.0.0. Furthermore, I still believe the code is more readable with such Clang Format configuration, so I suggest to switch on it in scope of this patchset.

Two other patches adjust the whitespace to the fixed formatting rules (one can find more info in the commit messages).

---

Finally, some good news: as a result of this PR, the code formatting is fine for all Clang Format versions from 11.0.0 to 18.0.0.