### PR TITLE
Update Clang version

### DIFF
--- a/cmake/toolchain/Clang.cmake
+++ b/cmake/toolchain/Clang.cmake
@@ -5,7 +5,7 @@
 # Copyright (C) 2020-2023 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-set(CMAKE_C_COMPILER "clang-6.0")
+set(CMAKE_C_COMPILER "clang-11")
 
 # XXX: Clang 15 changes the behaviour of -Wnull-pointer-arithmetics to control
 # -Wgnu-null-pointer-arithmetics either. Since uJIT is built with -Wextra

--- a/scripts/depends-build-20-04
+++ b/scripts/depends-build-20-04
@@ -1,5 +1,5 @@
 autoconf
-clang-6.0
+clang-11
 cmake
 gcc
 gcc-8=8.4.0-*


### PR DESCRIPTION
Clang is upgraded up to version 11.0.0 to make seamless migration from Ubuntu 20.04 to Ubuntu 22.04 (both distros provide the mentioned version of Clang toolchain from the default repositories).

Further Clang toolchain upgrades will be completed after full migration to Ubuntu 22.04.