### PR TITLE
Upgrade to macOS 12 in GitHub Actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,7 +42,7 @@ jobs:
             RUNNER: [ubuntu-20.04]
             TESTOPTIONS: -DUJIT_TEST_OPTIONS=-O4
           - OS: macOS
-            RUNNER: [macos-11]
+            RUNNER: [macos-12]
           - CC: Clang
             TOOLCHAIN: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/Clang.cmake
         exclude:


### PR DESCRIPTION
GitHub announced[1] that macos-11 has been deprecated and will no longer be available after 28.06.2024, so macos-12 will be used in uJIT CI as a result of the patch. There is also macos-13 runners provided by GitHub, but it uses Clang 15 compiler toolchain (AppleClang 15 to be precise), that requires another try to make a proper fix for all the spots where diagnostics has been suppressed in #63. Furthermore, it was found, that there is no bootstrap routine for macOS pipeline, hence, using the most suitable available version for now is OK (though, macOS pipeline should be refined later).

[1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories