### PR TITLE
Add Ubuntu 22.04 to GitHub Actions

### DIFF
--- a/.github/bootstrap/build-depends-22-04
+++ b/.github/bootstrap/build-depends-22-04
@@ -1,0 +1,9 @@
+autoconf
+clang-11
+cmake
+gcc
+gcc-12=12.3.0-*
+libc6-dev
+libstdc++-12-dev
+libstdc++6
+libtool

--- a/.github/bootstrap/test-depends-22-04
+++ b/.github/bootstrap/test-depends-22-04
@@ -1,0 +1,16 @@
+bc
+clang-format-11
+clang-tidy-11
+gdb
+graphviz
+libcmocka-dev=1.1.5-2
+libdigest-crc-perl
+libfile-find-rule-perl
+liblist-allutils-perl
+libtest-deep-perl
+libtext-table-perl
+perl
+python3
+python3-pip
+time
+valgrind

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         BUILDTYPE: [Debug, Minimal, Release]
-        DISTVER: [20.04]
+        DISTVER: [20.04, 22.04]
         LIBTYPE: [shared, static]
         CC: [GCC, Clang]
         include:


### PR DESCRIPTION
This patch extends the set of the supported platforms by Ubuntu 22.04 (Jammy Jellyfish). Fortunately, all the packages from the dependency list are the same except the GCC toolchain.