### PR TITLE
Fix rindex tail call recording

### DIFF
--- a/src/jit/lj_ffrecord.c
+++ b/src/jit/lj_ffrecord.c
@@ -1335,6 +1335,16 @@ static void recff_ujit_table_rindex(jit_State *J, RecordFFData *rd)
     tr = emitir(IRT(IR_TVARGF, IRT_PTR), tr, J->maxslot);
 
     J->base[0] = lj_ir_call(J, IRCALL_lj_tab_rawrindex_jit, tr);
+    /*
+     * By convention, any of returned values set to NULL is a signal
+     * for a side exit.
+     */
+    emitir(IRTG(IR_NE, IRT_PTR), J->base[0], lj_ir_kkptr(J, NULL));
+    /*
+     * TVLOAD is emitted with temporary NIL type, will be fixed
+     * later - see LJ_POST_FFSPECRET implementation.
+     */
+    emitir(IRTG(IR_TVLOAD, IRT_NIL), J->base[0], 0);
     J->postproc = LJ_POST_FFSPECRET;
   } else {
     recff_nyiu(J);

--- a/src/jit/lj_record.c
+++ b/src/jit/lj_record.c
@@ -1812,6 +1812,9 @@ void lj_record_ins(jit_State *J)
         if (!tvistruecond(&J2G(J)->tmptv2))
           lj_trace_err(J, LJ_TRERR_GFAIL);
 
+        if (bc_op(ins) == BC_HOTCNT)
+          ins = *(J->pc - 2);
+
         /*
          * In case of tail call, ins will point to CALL from caller function,
          * not to the original CALLT/CALLMT made in callee.

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/table/rindex/tailcall.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/table/rindex/tailcall.lua
@@ -53,3 +53,17 @@ do --- rindex return value check must not be broken
 	bar(tab)
 	bar(tab) -- should exit normally
 end
+
+do --- ensure correct HOTCNT handling (i.e. applying LJ_POST_FFSPECRET while J->pc-1 points to HOTCNT)
+	local function foo(tab)
+		return ujit.table.rindex(tab, "k1", "k2")
+	end
+
+	local function bar(tab)
+		for _ = 1, 5 do
+			foo(tab)
+		end
+	end
+
+	bar({k1 = {k2 = false}})
+end

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/table/rindex/tailcall.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/table/rindex/tailcall.lua
@@ -1,0 +1,55 @@
+do --- trace should not return to lower frame before checking rindex return value
+	local function foo(call_rindex, tab)
+		if call_rindex == false then return nil end
+		return ujit.table.rindex(tab, "k1", "k2")
+	end
+
+	local function bar(tab)
+		local ret = foo(true, tab)
+		-- compiled cycle just to link trace from foo() here
+		-- otherwise it will leave bar()
+		for _ = 1, 5 do end
+		-- stop further recordings
+		print("nyi bytecode")
+		return ret
+	end
+
+	foo(false, {})
+	foo(false, {})
+	foo(false, {})
+	foo(false, {})
+	foo(false, {})
+	foo(false, {}) -- record only nil branch
+
+	local tab = {k1 = {k2 = "str1"}}
+	bar(tab)
+	-- side trace which records rindex and will stop in bar()
+	bar(tab)
+	-- trace should exit correctly to start of foo() without unwinding to bar() frame
+	assert(bar({k1 = {k2 = 42}}) == 42)
+end
+
+do --- rindex return value check must not be broken
+	local function foo(call_rindex, tab)
+		if call_rindex == false then return nil end
+		return ujit.table.rindex(tab, "k1", "k2")
+	end
+
+	local function bar(tab)
+		foo(true, tab)
+		for _ = 1, 5 do end
+		print("nyi bytecode")
+	end
+
+	foo(false, {})
+	foo(false, {})
+	foo(false, {})
+	foo(false, {})
+	foo(false, {})
+	foo(false, {})
+
+	local tab = {k1 = {k2 = {}}}
+	bar(tab)
+	bar(tab)
+	bar(tab) -- should exit normally
+end

--- a/tests/impl/uJIT-tests-Lua/suite/table.t
+++ b/tests/impl/uJIT-tests-Lua/suite/table.t
@@ -285,4 +285,22 @@ $tester->run('rindex/no-recording.lua', args => '-p-')
   ->stdout_has('asynchronous abort')
 ;
 
+$tester->run('rindex/tailcall.lua', args => '-Ohotloop=3 -Ohotexit=2 -p-')
+  ->exit_ok()
+  ->stdout_matches(qr/.+TRACE.3.IR.+\s
+                      0024.rax.+p64.CALLL.+lj_tab_rawrindex_jit.+\(0023\)\s
+                      0025.+>.+p64.NE.+0024.+\[NULL\]\s
+                      0026.+rax.+>.+str.TVLOAD.0024\s
+                      0027.+>.+p32.RETF\s
+                      .+SNAP.+\#1\s
+                      .+TRACE.3.mcode.+/xs)
+  ->stdout_matches(qr/.+TRACE.6.IR.+\s
+                      0024.rax.+p64.CALLL.+lj_tab_rawrindex_jit.+\(0023\)\s
+                      0025.+>.+p64.NE.+0024.+\[NULL\]\s
+                      0026.+>.+tab.TVLOAD.0024\s
+                      0027.+>.+p32.RETF\s
+                      .+SNAP.+\#1\s
+                      .+TRACE.6.mcode.+/xs)
+;
+
 exit;

--- a/tests/impl/uJIT-tests-Lua/suite/table.t
+++ b/tests/impl/uJIT-tests-Lua/suite/table.t
@@ -301,6 +301,15 @@ $tester->run('rindex/tailcall.lua', args => '-Ohotloop=3 -Ohotexit=2 -p-')
                       0027.+>.+p32.RETF\s
                       .+SNAP.+\#1\s
                       .+TRACE.6.mcode.+/xs)
+  ->stdout_matches(qr/.+TRACE.7.IR.+\s
+                      0025.rax.+p64.CALLL.+lj_tab_rawrindex_jit.+\(0024\)\s
+                      0026.+>.+p64.NE.+0025.+\[NULL\]\s
+                      0027.+>.+fal.TVLOAD.0025\s
+                      .+LOOP.+\s
+                      0034.rax.+p64.CALLL.+lj_tab_rawrindex_jit.+\(0033\)\s
+                      0035.+>.+p64.NE.+0034.+\[NULL\]\s
+                      0036.+>.+fal.TVLOAD.0034\s
+                      .+TRACE.7.mcode.+/xs)
 ;
 
 exit;


### PR DESCRIPTION
Hi LuaVela team,

There are some problems with recording tail-called `rindex()`:

1. Since return type checks are emitted after `CALLT` (or `CALLMT`) recording, `RETF` instruction will be emitted before them:
    ```
    0024 rax      p64 CALLL  lj_tab_rawrindex_jit  (0023)
    0025       >  p32 RETF   tailcall.lua:7  [0x7fa5168ad168]
    0026       >  p64 NE     0024  [NULL]
    0027 rax   >  str TVLOAD 0024
    ```
    Which leads to situation when frame pointer will be unwinded to caller, but then trace exits due to failed return type check and starts executing calle's PC.
    Just to compare, this is IR with regular return (`RETF` is placed after checks):
    ```
    0024 rax      p64 CALLL  lj_tab_rawrindex_jit  (0023)
    0025       >  p64 NE     0024  [NULL]
    0026 rax   >  str TVLOAD 0024
    ....              SNAP   #1   [ ---- true ---- 0026 ]
    0027       >  p32 RETF   tailcall.lua:7  [0x7fb978f55170]
    ```
    In attached test this is the first example.
    This patch emits return value check before `RETF` and later fixes guard type. Example above will looks like:
    ```
    0024 rax      p64 CALLL  lj_tab_rawrindex_jit  (0023)
    0025       >  p64 NE     0024  [NULL]
    0026 rax   >  str TVLOAD 0024
    0027       >  p32 RETF  tailcall.lua:7  [0x7f6fb1db8168]
    ```
2. Return type check can get broken and doesn't actually check `lj_tab_rawrindex_jit`  result (since `J->base` will be pointing to previous frame by the time `LJ_POST_FFSPECRET` is applied). This is IR for the second test example (instead of rindex its argument `"k1"` is checked):
    ```
    0021          nil TVARG  0019  "k1"
    0022          nil TVARG  0021  "k2"
    0023 rdi      p64 TVARGF 0022  #3  
    0024          p64 CALLL  lj_tab_rawrindex_jit  (0023)
    0025       >  p32 RETF   tailcall.lua:38  [0x7f26b44a4168]
    0026       >  p64 NE     "k1"  [NULL]
    0027       >  tab TVLOAD "k1"
    ```
    Under O3 `lj_tab_rawrindex_jit` call will be completely purged out from assembled trace due to it, but `NE` and `TVLOAD` still be present and will check random registers.
    This patch fixes this case too:
    ```
    0024 rax      p64 CALLL  lj_tab_rawrindex_jit  (0023)
    0025       >  p64 NE     0024  [NULL]
    0026       >  tab TVLOAD 0024
    0027       >  p32 RETF   tailcall.lua:38  [0x7f360fc62170]
    ```
3. It's possible that `J->pc - 1` will point to `HOTCNT` bytecode instead of `CALL(M)` during `LJ_POST_FFSPECRET` fixup. This case covered by 3rd testcase.

PS. Also looks like its safe to remove assert for `CALLT` and `CALLMT`, since by the time of `LJ_POST_FFSPECRET` execution VM is already returned to lower frame and can't hit `CALLT` or `CALLMT`.

I'm not absolutely sure about correctness of the patch, please help to figure it out.
Thanks in advance!