### PR TITLE
Fix GCobj pointer comparison in BC_ISEQV/BC_ISNEV

### DIFF
--- a/src/vm_x86.dasc
+++ b/src/vm_x86.dasc
@@ -2709,7 +2709,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
       |  // Same types and not a primitive type. Compare GCobj or pvalue.
       |  i2gcr GCOBJ:RAa, BASE, RAa // RA := GCobj*
       |  i2gcr GCOBJ:RDa, BASE, RDa // RD := GCobj*
-      |  cmp RA, RD
+      |  cmp RAa, RDa
       |  je <1                          // Same GCobjs or pvalues?
       |  cmp RB, LJ_TISTABUD
       |  ja <2                          // Different objects and not table/ud?


### PR DESCRIPTION
When comparing GC objects payload (i.e. their `GCobj` pointers) in scope of `BC_ISEQV`/`BC_ISNEV` bytecodes, both values are loaded into the 64-bit registers, but only lower 32 bits are compared later. Hence, there might be the address parts clashing, leading to invalid comparison results, when the LSBs are the same, but the MSBs are not.

This register mischoice was introduced in the very first uJIT commit, since VM code had been taken intact from vanilla LuaJIT sources, but 128-bit TValue (and, ergo, 64-bit `GCobj` pointers) are uJIT specifics. So, this is likely a typo, undetected since 2015.

As a result of the patch, 64-bit registers are used in this `<cmp>` instruction. Unfortunately, I have no reproducer for this, so I can't provide a proper test for this changeset.