### PR TITLE
Upgrade to macOS 13 in GitHub Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -62,3 +62,4 @@ jobs:
         uses: ./.github/actions/run-tests
         with:
           cmakeflags: ${{ matrix.CMAKEFLAGS }}
+          toolchain: cmake/toolchain/MacOS.cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         BUILDTYPE: [Debug, Release]
-        DISTVER: [12]
+        DISTVER: [13]
         include:
           - BUILDTYPE: Debug
             CMAKEFLAGS: >-

--- a/cmake/toolchain/MacOS.cmake
+++ b/cmake/toolchain/MacOS.cmake
@@ -1,0 +1,21 @@
+# MacOS toolchain for building uJIT. To enable, run cmake like this:
+#
+# $ cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/MacOS.cmake ...other options...
+#
+# Copyright (C) 2020-2024 LuaVela Authors. See Copyright Notice in COPYRIGHT
+# Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
+
+# XXX: Clang 15 changes the behaviour of -Wnull-pointer-arithmetics to control
+# -Wgnu-null-pointer-arithmetics either. Since uJIT is built with -Wextra
+# (including -Wnull-pointer-arithmetics) and -Werror flags being set in
+# CMAKE_C_FLAGS list, compilation of src/utils/lj_alloc.c fails due to NULL
+# pointer arithmetics in TOP_FOOT_SIZE constant definition. Furthermore,
+# -Wno-gnu flag to silence GNU extension diagnostics for pointer arithmetic is
+# allowed since Clang 15 (https://github.com/llvm/llvm-project/issues/54444)
+# too. Considering everything above, tweak the CMAKE_C_FLAGS list for Clang
+# toolchain only for Clang 15.0.0 and later.
+# XXX: Unlike Linux distributions, we only support one version of macOS, so the
+# compiler to be used is well-defined.
+# Taking into account all of the above, just provide a tiny tweak for
+# CMAKE_C_FLAGS, nothing more.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-null-pointer-arithmetic")


### PR DESCRIPTION
GitHub announced in https://github.com/actions/runner-images/issues/10721 that `macos-12` has been deprecated and will no longer be available after 03.12.2024, so `macos-13` will be used in uJIT CI as a result of the patchset. The first patch also introduces the new CMake toolchain file with a tiny tweak (and a huge reasoning for it) to make AppleClang happy on `macOS-13` (see more details in #63).

Follows up #63

Signed-off-by: Igor Munkin <imun@cpan.org>