### PR TITLE
Bump CMake minimal version up to 3.5

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Copyright (C) 2020-2025 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-cmake_minimum_required (VERSION 3.3.2 FATAL_ERROR)
-
 include(ExternalProject)
 
 set(THIRD_PARTY_INCLUDE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,8 @@ set_property(CACHE UJIT_TEST_LIB_TYPE PROPERTY STRINGS ${UJIT_TEST_LIB_TYPE_VALU
 message(STATUS "UJIT_TEST_LIB_TYPE='${UJIT_TEST_LIB_TYPE}'")
 
 # Check that UJIT_TEST_LIB_TYPE value is correct
-# In CMake 3.5 we'll be able to use IN_LIST here
-list(FIND UJIT_TEST_LIB_TYPE_VALUES ${UJIT_TEST_LIB_TYPE} TEST_LIB_TYPE_INDEX)
-if(TEST_LIB_TYPE_INDEX EQUAL -1)
-  message(FATAL_ERROR "UJIT_TEST_LIB_TYPE must be \"static\" or \"shared\"")
+if(NOT UJIT_TEST_LIB_TYPE IN_LIST UJIT_TEST_LIB_TYPE_VALUES)
+  message(FATAL_ERROR "UJIT_TEST_LIB_TYPE must be one of the following: ${UJIT_TEST_LIB_TYPE_VALUES}.")
 endif()
 
 # Name of the CLI binary to be used in tests:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
 # --- Initial setup ------------------------------------------------------------
-cmake_minimum_required(VERSION 3.3.2)
+cmake_minimum_required(VERSION 3.5)
 project(UJIT C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
 # --- Initial setup ------------------------------------------------------------
-cmake_minimum_required(VERSION 3.3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.3.2)
 project(UJIT C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -23,7 +23,6 @@ function(add_clang_tidy_check TARGET_NAME)
   set(singleValues)
   set(multiValues FILES DEPENDENCIES)
 
-  include(CMakeParseArguments) # if we update to CMake >= 3.5, can remove this line
   cmake_parse_arguments(${prefix}
                         "${noValues}"
                         "${singleValues}"

--- a/cmake/MakeSourceList.cmake
+++ b/cmake/MakeSourceList.cmake
@@ -26,7 +26,6 @@ function(make_source_list list)
   set(singleValues)
   set(multiValues SOURCES)
 
-  include(CMakeParseArguments) # if we update to CMake >= 3.5, can remove this line
   cmake_parse_arguments(${prefix}
                         "${noValues}"
                         "${singleValues}"

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Copyright (C) 2020-2025 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-cmake_minimum_required (VERSION 3.3.2 FATAL_ERROR)
-
 set(UJIT_MAN_PAGE ${CMAKE_CURRENT_SOURCE_DIR}/ujit.1)
 set(UJIT_COMPRESSED_MAN_PAGE ${CMAKE_CURRENT_BINARY_DIR}/ujit.1.gz)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2025 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-cmake_minimum_required (VERSION 3.3.2 FATAL_ERROR)
 enable_language (ASM)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}) # for sub-projects

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Copyright (C) 2020-2025 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-cmake_minimum_required (VERSION 3.3.2 FATAL_ERROR)
-
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
 )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2025 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-cmake_minimum_required (VERSION 3.3.2 FATAL_ERROR)
 enable_language(C)
 
 include(MakeSourceList)


### PR DESCRIPTION
According to the docs[1], compatibility with versions of CMake older than 3.5 is deprecated since the version 3.27. Ubuntu 24.04 provides CMake 3.28.3 by default, so uJIT configuration starts spoiling the diagnostics with the following warning:
```
CMake Deprecation Warning at CMakeLists.txt:11 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Since there is no particular policies specified in the project CMake machinery, there is no need to stick to the 3.3.2 version. However, migration to the newest version requires more precise changes, so this patch only bumps the minimal required version up to 3.5.

As a result, all explicit includes for `CMakeParseArguments` module have been removed, because `cmake_parse_arguments` command is implemented natively since CMake 3.5, and `list(FIND ...)` hack in the root CMakeLists.txt has been replaced with `IN_LIST` operator.

---

Besides there are to more tiny changes, related to `cmake_mininum_required`.

First of all, the `FATAL_ERROR` option is accepted but ignored by CMake 2.6 and higher. It should be specified so CMake versions 2.4 and lower fail with an error instead of just a warning. Since compatibility with versions of CMake older than 2.8.12 is already deprecated, there is no need to provide this option anymore.

Furthermore, `cmake_minimum_required` should be called at the beginning of the top-level CMakeLists.txt (even before calling the `project` command) to set the version and the policy settings before invoking other commands whose behavior they may affect. All other calls (especially, setting the same version) are definitely excess. Hence, the patch drops `cmake_minimum_required` calls from all CMakeLists.txt except the root one.

---

[1]: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

Signed-off-by: Igor Munkin <imun@cpan.org>