### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# Read the Docs configuration file for Sphinx projects.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
+# Copyright (C) 2020-2025 LuaVela Authors. See Copyright Notice in COPYRIGHT
+# Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
+
+# The version of the ReadTheDocs config file.
+version: 2
+
+# Set the OS, Python version and other tools being required.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx.
+sphinx:
+  configuration: docs/conf.py
+
+# Optional but recommended: declare the Python requirements, required to build
+# your documentation.
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html.
+python:
+  install:
+    - requirements: .github/bootstrap/docs-requirements.txt


### PR DESCRIPTION
This patch adds the required configuration file to the uJIT repository root, as described in the Read the Docs tutorial[1].

[1]: https://docs.readthedocs.com/platform/stable/config-file/index.html

Signed-off-by: Igor Munkin <imun@cpan.org>