### PR TITLE
Bump missing copyright date

### DIFF
--- a/cmake/toolchain/MacOS.cmake
+++ b/cmake/toolchain/MacOS.cmake
@@ -2,7 +2,7 @@
 #
 # $ cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/MacOS.cmake ...other options...
 #
-# Copyright (C) 2020-2024 LuaVela Authors. See Copyright Notice in COPYRIGHT
+# Copyright (C) 2020-2025 LuaVela Authors. See Copyright Notice in COPYRIGHT
 # Copyright (C) 2015-2020 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
 # XXX: Clang 15 changes the behaviour of -Wnull-pointer-arithmetics to control


### PR DESCRIPTION
To make the patch, committed in 5133b1d10be23c83caaa5830aaf01cb697c5b438 ("Bump copyright date"), `bump.sh` has been run on the outdated local master branch (i.e. the commit b17c2b69e99d63fa4315167b42edf7ba9a2c1e41 ("Introduce macOS toolchain setup for CMake") has not been pulled from the upstream). Hence, the flowerbox in the introduced CMake file has not been touched by the script.

This patch updates the year in the aforementioned flowerbox via `bump.sh`.

Follows up #73

Signed-off-by: Igor Munkin <imun@cpan.org>